### PR TITLE
Adding detection of multiple boards at once

### DIFF
--- a/src/ofxAruco.h
+++ b/src/ofxAruco.h
@@ -20,57 +20,69 @@
 class ofxAruco: public ofThread {
 public:
 	ofxAruco();
-
+    
 	void setThreaded(bool threaded); // defaults to true
 	void setup(string calibrationFile,float w, float h, string boardConfig="", float markerSize=.15);
 	void setupXML(string calibrationXML,float w, float h, string boardConfig="", float markerSize=.15);
-
+    
+    void addBoardConf(string boardConfig="");
+    
 	void detectMarkers(ofPixels & pixels);
-	void detectBoard(ofPixels & pixels);
-
+	void detectBoards(ofPixels & pixels);
+    
 	void draw();
-
+    
 	vector<aruco::Marker> & getMarkers();
-	aruco::Board & getBoard();
+    //    bgraf
+    //	aruco::Board & getBoard();
+    vector<aruco::Board> & getBoards();
 	float getBoardProbability();
-
+    vector<float> getBoardProbabilities();
+    
 	int getNumMarkers();
 	int getNumBoards();
-
+    
 	void begin(int marker);
-	void beginBoard();
+    //    bgraf
+    //	void beginBoard();
+    void beginBoard(int boardnum);
 	void end();
-
+    
 	ofMatrix4x4 getProjectionMatrix();
 	ofMatrix4x4 getModelViewMatrix(int marker);
-	ofMatrix4x4 getModelViewMatrixBoard();
-
-	ofVec3f getBoardTranslation();
-	ofQuaternion getBoardRotation();
-
+	ofMatrix4x4 getModelViewMatrixBoard(int board);
+    
+    // bgraf (int board added)
+	ofVec3f getBoardTranslation(int board);
+	ofQuaternion getBoardRotation(int board);
+    
 	void getBoardImage(ofPixels & pixels);
 	void getMarkerImage(int markerID, int size, ofPixels & pixels);
 	void getThresholdImage(ofPixels & pixels);
-
+    
 	double getThresholdParam1();
 	double getThresholdParam2();
 	void setThresholdParams(double param1, double param2);
 	void setThresholdMethod(aruco::MarkerDetector::ThresholdMethods method);
-
-	aruco::BoardConfiguration & getBoardConfig();
-
+    
+    // bgraf
+    //	aruco::BoardConfiguration & getBoardConfig();
+    vector<aruco::BoardConfiguration> & getBoardConfigs();
+    
 private:
 	void threadedFunction();
 	void findMarkers(ofPixels & pixels);
-	void findBoard(ofPixels & pixels);
-
+    // bgraf
+    //	void findBoard(ofPixels & pixels);
+    void findBoards(ofPixels & pixels);
+    
 	ofPixels frontPixels, backPixels, intraPixels;
 	bool newDetectMarkers, newDetectBoard;
 	Poco::Condition condition;
-
+    
 	aruco::MarkerDetector detector;
 	aruco::BoardDetector boardDetector;
-
+    
 	struct TrackedMarker{
 		aruco::Marker marker;
 		int age;
@@ -78,20 +90,25 @@ private:
 	vector<aruco::Marker> markers,backMarkers,intraMarkers;
 	vector<TrackedMarker> prevMarkers;
 	int maxAge;
-	aruco::Board board;
-	aruco::BoardConfiguration boardConfig;
-	float boardProbability;
+    // bgraf
+    //	aruco::Board board;
+    //	aruco::BoardConfiguration boardConfig;
+    //    float boardProbability;
+    vector<aruco::Board> boards;
+    vector<aruco::BoardConfiguration> boardConfigs;
+	vector<float> boardProbabilities;
+    
 	aruco::CameraParameters camParams;
-
+    
 	float markerSize;
-
+    
 	cv::Size size;
-
+    
 	double projMatrix[16];
 	float projfMatrix[16];
 	ofMatrix4x4 ofprojMatrix;
-
-
+    
+    
 	aruco::Marker * findMarker(int id);
 	TrackedMarker * findTrackedMarker(int id);
 	bool threaded;


### PR DESCRIPTION
Multiple boardConfigs are stored in the vector 'boardConfigs', to add a config use .addBoardConf(string filepath).

The changes aren't as big as the line numbers say, I maybe did some strange formatting... Basically I used the concept of markers for the boards as well, by moving everything to a vector of boards and creating the appropriate methods. There's no way to remove a specific board though. Also the example isn't updated yet (but still works since the api is "backwards-compatible").
